### PR TITLE
Potential fix for code scanning alert no. 41: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -52,7 +52,6 @@ jobs:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.UPPTIME_WORKFLOW_TOKEN }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@65aad8bba77c40ec051f30e7329563f7f4cfab6e # v1.43.9
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/z-shell/status/security/code-scanning/41](https://github.com/z-shell/status/security/code-scanning/41)

To fix this without changing intended functionality, remove the dynamic full-secrets export and only pass the specific secret actually needed by the step.

Best fix in this file: in `.github/workflows/setup.yml`, under the **Update response time** step, delete the `SECRETS_CONTEXT: ${{ toJson(secrets) }}` environment entry and keep `GH_PAT: ${{ secrets.UPPTIME_WORKFLOW_TOKEN }}`. This preserves the authentication behavior while preventing all repository/organization secrets from being sent to the runner context for that step.

No new imports, methods, or definitions are required (YAML workflow edit only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
